### PR TITLE
Dino

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -127,3 +127,12 @@ dmypy.json
 
 # Pyre type checker
 .pyre/
+
+# GroundingDINO Model
+*.pth
+
+# Data
+*.jpeg
+*.jpg
+*.png
+*.txt

--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ To auto-annotate Grounding DINO model, we need to give text prompt that correspo
 python3 dino.py --dataset images/ --prompt prompt.json
 ```
 
-## 1. ONNX Model
+## 2. ONNX Model
 
 <details>
   <summary>Args</summary>
@@ -113,7 +113,7 @@ python3 autoAnnot.py --txt --dataset images/ --classes classes.txt --model model
 ```
 python3 autoAnnot.py --txt --dataset images/ --classes classes.txt --model models/model.onnx --size 224 --confidence 0.75 --remove 'person' 'car
 ```
-## 2. YOLO Model
+## 3. YOLO Model
 
 <details>
   <summary>Args</summary>

--- a/README.md
+++ b/README.md
@@ -1,11 +1,17 @@
 # autoAnnoter
-autoAnnoter its a tool to auto annotate data using a exisiting model
+autoAnnoter: Its a tool to auto annotate data using a exisiting model
 
-## 🚀 New Update (01-06-2023)
-### Auto Annotate using YOLO-NAS Model 🥳
-We can auto annotate data using new YOLO-NAS model. 
+## We can auto annotate any class 🚀 New Update (12-06-2023)
+### 🥳 Auto Annotate using Grounding DINO Model 🦕
+We can auto annotate **any class** on our data using new Grounding DINO model.<br>
+No need of any pre-trained or any custom model to auto-annotate.
+
+### About Grounding DINO 🦕
+Grounding DINO, by marrying **Transformer-based detector** DINO with grounded pre-training, which can detect arbitrary objects with human inputs such as category names or referring expressions. 
 
 ## Updates
+- (**01-06-2023**) **YOLO-NAS** Auto Annotation
+  - Auto Annotate using YOLO-NAS Model
 - (**25-04-2023**): We can remove any classes from auto annotation. So that we can create new set of dataset using existing model.
   Example:
   - If we need to create a people detection model. We can create new dataset from existing COCO model.
@@ -37,6 +43,47 @@ git clone https://github.com/naseemap47/autoAnnoter.git
 cd autoAnnoter/
 pip3 install -r requirements.txt
 ```
+
+## 1. Grounding DINO 🦕
+Grounding DINO is text to detection model. So we need to give text prompt that correspond to respective class.<br>
+To do this, we needs to create [prompt.json](https://github.com/naseemap47/autoAnnoter/blob/dino/prompt.json) <br>
+
+**JSON keys** should be text prompt to Grounding DINO model.<br>
+But the values for the each keys should be **class names** for that detection.<br>
+
+### Example:
+Here I need to train one custom model that can predict **high quality cap** and **low quality cap**.<br>
+So for this I give my **Grounding DINO** text prompt as **red cap** and **yellow caps**, to annotate my **high quality cap** and **low quality cap** classes.<br>
+I give this example to show you that, some times we need to give **Grounding DINO** text prompt as more elaborate way, like my example.
+
+![out11](https://github.com/naseemap47/autoAnnoter/assets/88816150/df2ebb71-ad67-4bce-9099-cd9857a4cfcd)
+
+
+```
+{
+    "red caps": "high quality cap",
+    "yellow caps": "low quality cap"
+}
+``` 
+### This approch we can use when the object is same, but have different feature like color.
+
+<details>
+  <summary>Args</summary>
+  
+  `-i`, `--dataset`: path to dataset/dir <br>
+  `-p`, `--prompt`: path to prompt.json <br>
+  `-bt`, `--box_thld`: Box Threshold <br>
+  `-tt`, `--txt_thld`: text threshold
+  
+</details>
+
+To auto-annotate Grounding DINO model, we need to give text prompt that correspond to respective class. 
+
+**Example:**
+```
+python3 dino.py --dataset images/ --prompt prompt.json
+```
+
 ## 1. ONNX Model
 
 <details>

--- a/anot_utils.py
+++ b/anot_utils.py
@@ -3,6 +3,8 @@ import numpy as np
 import os
 import xml.etree.ElementTree as ET
 from lxml import etree
+from torch import Tensor
+import torch
 DEFAULT_ENCODING = 'utf-8'
 
 
@@ -248,3 +250,27 @@ def get_BBoxYOLONAS(img, yolo_model, detect_conf, class_name_list, remove_list):
                 confidence.append(cnf)
 
     return bbox_list, class_ids, confidence
+
+
+# Convert CXCYWH to XYXY
+def box_cxcywh_to_xyxy(boxes: Tensor) -> Tensor:
+    """
+    Converts bounding boxes from (cx, cy, w, h) format to (x1, y1, x2, y2) format.
+    (cx, cy) refers to center of bounding box
+    (w, h) are width and height of bounding box
+    Args:
+        boxes (Tensor[N, 4]): boxes in (cx, cy, w, h) format which will be converted.
+
+    Returns:
+        boxes (Tensor(N, 4)): boxes in (x1, y1, x2, y2) format.
+    """
+    # We need to change all 4 of them so some temporary variable is needed.
+    cx, cy, w, h = boxes.unbind(-1)
+    x1 = cx - 0.5 * w
+    y1 = cy - 0.5 * h
+    x2 = cx + 0.5 * w
+    y2 = cy + 0.5 * h
+
+    boxes = torch.stack((x1, y1, x2, y2), dim=-1)
+
+    return boxes

--- a/dino.py
+++ b/dino.py
@@ -74,7 +74,7 @@ for img_path in img_list:
     print(f'Successfully Annotated {file_name}')
 
 # Save Labe Map
-with open(f"{args['dataset']}/classes.txt", "w") as output:
+with open(os.path.join(args['dataset'], 'classes.txt'), "w") as output:
     for i in txt_prompt.keys():
         output.write(f'{i}\n')
-print(f'[INFO] Saved Labelmap to: {args["dataset"]}/classes.txt')
+print(f"[INFO] Saved Labelmap to: {os.path.join(args['dataset'], 'classes.txt')}")

--- a/dino.py
+++ b/dino.py
@@ -76,5 +76,5 @@ for img_path in img_list:
 # Save Labe Map
 with open(os.path.join(args['dataset'], 'classes.txt'), "w") as output:
     for i in txt_prompt.keys():
-        output.write(f'{i}\n')
+        output.write(f'{txt_prompt[i]}\n')
 print(f"[INFO] Saved Labelmap to: {os.path.join(args['dataset'], 'classes.txt')}")

--- a/dino.py
+++ b/dino.py
@@ -8,17 +8,31 @@ import json
 import torch
 import cv2
 import os
+import wget
 import argparse
 
 
 ap = argparse.ArgumentParser()
 ap.add_argument("-i", "--dataset", type=str, required=True,
                 help="path to dataset/dir")
+ap.add_argument("-p", "--prompt", type=str, required=True,
+                help="path to prompt.json")
+ap.add_argument("-bt", "--box_thld", type=float, default=0.35,
+                help="Box Threshold")
+ap.add_argument("-tt", "--txt_thld", type=str, default=0.25,
+                help="text threshold")
 args = vars(ap.parse_args())
 
 
-CONFIG_PATH = 'GroundingDINO/groundingdino/config/GroundingDINO_SwinT_OGC.py'
+CONFIG_PATH = os.path.join('GroundingDINO', 'groundingdino', 'config', 'GroundingDINO_SwinT_OGC.py')
+if not os.path.exists("groundingdino_swint_ogc.pth"):
+    print(
+        f"[INFO] GroundingDINO Model NOT Found!!! \n \
+        [INFO] Downloading GroundingDINO Model..."
+    )
+    wget.download("https://github.com/IDEA-Research/GroundingDINO/releases/download/v0.1.0-alpha/groundingdino_swint_ogc.pth")
 WEIGHTS_PATH = "groundingdino_swint_ogc.pth"
+
 transform = T.Compose(
     [
         T.RandomResize([800], max_size=1333),
@@ -27,12 +41,10 @@ transform = T.Compose(
     ]
 )
 
-BOX_TRESHOLD = 0.35
-TEXT_TRESHOLD = 0.25
-txt_prompt = json.load(open('prompt.json'))
+BOX_TRESHOLD = args['box_thld']
+TEXT_TRESHOLD = args['txt_thld']
+txt_prompt = json.load(open(args['prompt']))
 TEXT_PROMPT = ', '.join([str(elem) for elem in txt_prompt])
-print(TEXT_PROMPT)
-# TEXT_PROMPT = "glass most to the right"
 
 model = load_model(CONFIG_PATH, WEIGHTS_PATH)
 

--- a/dino.py
+++ b/dino.py
@@ -1,0 +1,98 @@
+from GroundingDINO.groundingdino.util.inference import load_model, load_image, predict, annotate
+from torchvision.ops import box_convert
+from anot_utils import save_yolo
+import supervision as sv
+import cv2
+import numpy as np
+import GroundingDINO.groundingdino.datasets.transforms as T
+from typing import Tuple
+from PIL import Image
+import glob
+import os
+import json
+import torch
+from torch import Tensor
+import argparse
+
+
+ap = argparse.ArgumentParser()
+ap.add_argument("-i", "--dataset", type=str, required=True,
+                help="path to dataset/dir")
+args = vars(ap.parse_args())
+
+
+def box_cxcywh_to_xyxy(boxes: Tensor) -> Tensor:
+    """
+    Converts bounding boxes from (cx, cy, w, h) format to (x1, y1, x2, y2) format.
+    (cx, cy) refers to center of bounding box
+    (w, h) are width and height of bounding box
+    Args:
+        boxes (Tensor[N, 4]): boxes in (cx, cy, w, h) format which will be converted.
+
+    Returns:
+        boxes (Tensor(N, 4)): boxes in (x1, y1, x2, y2) format.
+    """
+    # We need to change all 4 of them so some temporary variable is needed.
+    cx, cy, w, h = boxes.unbind(-1)
+    x1 = cx - 0.5 * w
+    y1 = cy - 0.5 * h
+    x2 = cx + 0.5 * w
+    y2 = cy + 0.5 * h
+
+    boxes = torch.stack((x1, y1, x2, y2), dim=-1)
+
+    return boxes
+
+
+
+CONFIG_PATH = 'GroundingDINO/groundingdino/config/GroundingDINO_SwinT_OGC.py'
+WEIGHTS_PATH = "groundingdino_swint_ogc.pth"
+transform = T.Compose(
+    [
+        T.RandomResize([800], max_size=1333),
+        T.ToTensor(),
+        T.Normalize([0.485, 0.456, 0.406], [0.229, 0.224, 0.225]),
+    ]
+)
+
+BOX_TRESHOLD = 0.35
+TEXT_TRESHOLD = 0.25
+txt_prompt = json.load(open('prompt.json'))
+TEXT_PROMPT = ', '.join([str(elem) for elem in txt_prompt])
+print(TEXT_PROMPT)
+# TEXT_PROMPT = "glass most to the right"
+
+model = load_model(CONFIG_PATH, WEIGHTS_PATH)
+
+img_list = glob.glob(os.path.join(args["dataset"], '*.jpg')) + \
+    glob.glob(os.path.join(args["dataset"], '*.jpeg')) + \
+    glob.glob(os.path.join(args["dataset"], '*.png'))
+
+for img_path in img_list:
+    folder_name, file_name = os.path.split(img_path)
+    img = cv2.imread(img_path)
+    h, w, _ = img.shape
+    img = cv2.cvtColor(img, cv2.COLOR_BGR2RGB)
+    img = Image.fromarray(img)
+    image = np.asarray(img)
+    image_transformed, _ = transform(img, None)
+    bbox_list, logits, phrases = predict(
+        model=model, 
+        image=image_transformed, 
+        caption=TEXT_PROMPT, 
+        box_threshold=BOX_TRESHOLD, 
+        text_threshold=TEXT_TRESHOLD
+    )
+    print(bbox_list, logits, phrases)
+    class_list = [int(list(txt_prompt).index(value)+1) for value in phrases]
+    print(class_list)
+    bbox_list = bbox_list * torch.Tensor([w, h, w, h])
+    bbox_list = box_cxcywh_to_xyxy(boxes=bbox_list).numpy()
+    save_yolo(folder_name, file_name, w, h, bbox_list, class_list)
+    print(f'Successfully Annotated {file_name}')
+
+# Save Labe Map
+with open(f"{args['dataset']}/classes.txt", "w") as output:
+    for i in txt_prompt.keys():
+        output.write(f'{i}\n')
+print(f'[INFO] Saved Labelmap to: {args["dataset"]}/classes.txt')

--- a/prompt.json
+++ b/prompt.json
@@ -1,0 +1,4 @@
+{
+    "bottle": "glass",
+    "person": "boy"
+}


### PR DESCRIPTION
## We can auto annotate any class 🚀 New Update (12-06-2023)
### 🥳 Auto Annotate using Grounding DINO Model 🦕
We can auto annotate **any class** on our data using new Grounding DINO model.<br>
No need of any pre-trained or any custom model to auto-annotate.

### About Grounding DINO 🦕
Grounding DINO, by marrying **Transformer-based detector** DINO with grounded pre-training, which can detect arbitrary objects with human inputs such as category names or referring expressions. 

## 1. Grounding DINO 🦕
Grounding DINO is text to detection model. So we need to give text prompt that correspond to respective class.<br>
To do this, we needs to create [prompt.json](https://github.com/naseemap47/autoAnnoter/blob/dino/prompt.json) <br>

**JSON keys** should be text prompt to Grounding DINO model.<br>
But the values for the each keys should be **class names** for that detection.<br>

### Example:
Here I need to train one custom model that can predict **high quality cap** and **low quality cap**.<br>
So for this I give my **Grounding DINO** text prompt as **red cap** and **yellow caps**, to annotate my **high quality cap** and **low quality cap** classes.<br>
I give this example to show you that, some times we need to give **Grounding DINO** text prompt as more elaborate way, like my example.

![out11](https://github.com/naseemap47/autoAnnoter/assets/88816150/df2ebb71-ad67-4bce-9099-cd9857a4cfcd)


```
{
    "red caps": "high quality cap",
    "yellow caps": "low quality cap"
}
``` 
### This approch we can use when the object is same, but have different feature like color.

<details>
  <summary>Args</summary>
  
  `-i`, `--dataset`: path to dataset/dir <br>
  `-p`, `--prompt`: path to prompt.json <br>
  `-bt`, `--box_thld`: Box Threshold <br>
  `-tt`, `--txt_thld`: text threshold
  
</details>

To auto-annotate Grounding DINO model, we need to give text prompt that correspond to respective class. 

**Example:**
```
python3 dino.py --dataset images/ --prompt prompt.json
```